### PR TITLE
Make sure a middleware has a corresponding type/field definition

### DIFF
--- a/packages/core/src/module/resolvers.ts
+++ b/packages/core/src/module/resolvers.ts
@@ -16,6 +16,7 @@ import {
   normalizeResolveMiddlewareMap,
   mergeNormalizedResolveMiddlewareMaps,
   NormalizedResolveMiddlewareMap,
+  validateResolveMiddlewareMap,
 } from "../shared/middleware";
 
 const resolverMetadataProp = Symbol("metadata");
@@ -32,10 +33,15 @@ export function createResolvers(
   }
 ) {
   const ensure = ensureImplements(metadata);
+  const normalizedModuleMiddlewareMap = normalizeResolveMiddlewareMap(
+    config.resolveMiddlewares
+  );
   const middlewareMap = mergeNormalizedResolveMiddlewareMaps(
     app.resolveMiddlewareMap,
-    normalizeResolveMiddlewareMap(config.resolveMiddlewares)
+    normalizedModuleMiddlewareMap
   );
+
+  validateResolveMiddlewareMap(normalizedModuleMiddlewareMap, metadata);
 
   const resolvers = mergeResolvers(config);
 

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -16,6 +16,14 @@ export class ExtraResolverError extends ExtendableBuiltin(Error) {
   }
 }
 
+export class ExtraMiddlewareError extends ExtendableBuiltin(Error) {
+  constructor(message: string, ...rest: string[]) {
+    super(composeMessage(message, ...rest));
+    this.name = this.constructor.name;
+    this.message = composeMessage(message, ...rest);
+  }
+}
+
 export class ResolverDuplicatedError extends ExtendableBuiltin(Error) {
   constructor(message: string, ...rest: string[]) {
     super(composeMessage(message, ...rest));
@@ -39,7 +47,7 @@ export function useLocation({ dirname, id }: { id: ID; dirname?: string }) {
     ? `Module "${id}" located at ${dirname}`
     : [
         `Module "${id}"`,
-        `Hint: pass __dirname to "dirname" option of your modules to get more insightful errors :)`,
+        `Hint: pass __dirname to "dirname" option of your modules to get more insightful errors`,
       ].join("\n");
 }
 


### PR DESCRIPTION
We don't want to pass a module-level middlewares that are not related to the module.
Not because it's dangerous or something but to prevent unused middlewares.